### PR TITLE
 Fixes #4: Image now assumes config location `/config/tellus.tml`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Tellus
 A bot for planing and applying Terraform code.
+
+## Configuration
+The configuration file is assumed to be located on `/config/tellus.yml`.
+To override this behavior set the environment variable `CONFIG_FILE`
+to the new location of the configuration file.

--- a/k8s.yml
+++ b/k8s.yml
@@ -27,8 +27,6 @@ spec:
             - mountPath: /config
               name: config
           env:
-            - name: CONFIG_FILE
-              value: /config/tellus.yml
             - name: PORT
               value: "8080"
       volumes:

--- a/k8s.yml
+++ b/k8s.yml
@@ -28,7 +28,7 @@ spec:
               name: config
           env:
             - name: CONFIG_FILE
-              value: /config/config.yml
+              value: /config/tellus.yml
             - name: PORT
               value: "8080"
       volumes:
@@ -62,7 +62,7 @@ metadata:
   labels:
     app: tellus
 data:
-  config.yml: |
+  tellus.yml: |
     repositoryRootDirectory: /repos/
     github:
       privateKey:

--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 
 var PORT = os.Getenv("PORT")
 
+const DefaultConfigurationLocation = "/config/tellus.yml"
+
 type Configuration struct {
 	RepositoryRootDirectory string 	`yaml:"repositoryRootDirectory"`
 	Github struct{
@@ -24,14 +26,8 @@ type Configuration struct {
 
 func main() {
 	log.Printf("Starting tellus!")
-	fileLocation := os.Getenv("CONFIG_FILE")
-	bytes, err := ioutil.ReadFile(fileLocation)
+	config, err := getConfiguration()
 	if err != nil {
-		panic(err.Error())
-	}
-	log.Print(string(bytes))
-	var config Configuration
-	if err = yaml.Unmarshal(bytes, &config); err != nil {
 		panic(err.Error())
 	}
 	log.Print(config)
@@ -44,4 +40,26 @@ func main() {
 		log.Print(err.Error())
 	}
 	http.ServeHttpClient(PORT, tellusClient)
+}
+
+func getConfiguration() (*Configuration, error) {
+	fileLocation := getConfigLocation()
+	bytes, err := ioutil.ReadFile(fileLocation)
+	if err != nil {
+		return nil, err
+	}
+	log.Print(string(bytes))
+	var config Configuration
+	if err = yaml.Unmarshal(bytes, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func getConfigLocation() string {
+	fl := os.Getenv("CONFIG_FILE")
+	if fl == "" {
+		fl = DefaultConfigurationLocation
+	}
+	return fl
 }


### PR DESCRIPTION
To override this behavior one can still set the enviroment variable
`CONFIG_FILE`.